### PR TITLE
temporary workaround for period issue

### DIFF
--- a/src/entry-helpers.ts
+++ b/src/entry-helpers.ts
@@ -11,16 +11,12 @@ export const genericError = (e: Error) =>
 
 export const waitForCallback = (text: string) => () => {
   const textArea = document.activeElement as HTMLTextAreaElement;
-  let expectedText = text.toUpperCase();
   let expectedTextWithoutPeriod = text.replace(/\./g,'').toUpperCase();
-  let actualText = textArea.value.toUpperCase();
+  let actualTextWithoutPeriod = textArea.value.replace(/\./g,'').toUpperCase();
 
-  // relaxing constraint for equality because of the period issue.
-  if ((actualText === expectedText) || (actualText === expectedTextWithoutPeriod))
-  {
-    return;
-  }
-  else
+  // relaxing constraint for equality because there is an issue with periods. 
+  // in some cases, userEvent.type doesn't type the periods.
+  if (actualTextWithoutPeriod !== expectedTextWithoutPeriod)
   {
     throw new Error("Typing not complete");
   }
@@ -50,11 +46,12 @@ export const getConfigFromPage = (page: string) => {
 };
 
 export const pushBullets = async (bullets: string[], title: string = "") => {
-  // There is an issue with periods which happens only for the first bullet. 
+  // There is an issue with periods which happens only for the first bullet that contains a period.
   // Deliberrately adding a period, so that subsequent bullets don't face that issue.
+  // Doesn't always work if title is empty.
+  // This period issue is a big mystery.
   bullets.unshift(title + ".");
 
-  // TODO: Nest bullets under title bullet.
   for (const index in bullets) {
     const bullet = bullets[index];
     await asyncType(bullet);

--- a/src/entry-helpers.ts
+++ b/src/entry-helpers.ts
@@ -11,7 +11,17 @@ export const genericError = (e: Error) =>
 
 export const waitForCallback = (text: string) => () => {
   const textArea = document.activeElement as HTMLTextAreaElement;
-  if (textArea.value.toUpperCase() !== text.toUpperCase()) {
+  let expectedText = text.toUpperCase();
+  let expectedTextWithoutPeriod = text.replace(/\./g,'').toUpperCase();
+  let actualText = textArea.value.toUpperCase();
+
+  // relaxing constraint for equality because of the period issue.
+  if ((actualText === expectedText) || (actualText === expectedTextWithoutPeriod))
+  {
+    return;
+  }
+  else
+  {
     throw new Error("Typing not complete");
   }
 };
@@ -39,7 +49,12 @@ export const getConfigFromPage = (page: string) => {
   return Object.fromEntries(entries);
 };
 
-export const pushBullets = async (bullets: string[]) => {
+export const pushBullets = async (bullets: string[], title: string = "") => {
+  // There is an issue with periods which happens only for the first bullet. 
+  // Deliberrately adding a period, so that subsequent bullets don't face that issue.
+  bullets.unshift(title + ".");
+
+  // TODO: Nest bullets under title bullet.
   for (const index in bullets) {
     const bullet = bullets[index];
     await asyncType(bullet);


### PR DESCRIPTION
@dvargas92495 

Temporary fix for https://github.com/dvargas92495/roam-js-extensions/issues/47

Calling `pushBullets` with the title param causes the period issue for the first(title) bullet, but the subsequent ones are typed properly.