### PR TITLE
Edit Page-synonyms docs to include warning

### DIFF
--- a/pages/docs/extensions/page-synonyms.mdx
+++ b/pages/docs/extensions/page-synonyms.mdx
@@ -11,4 +11,4 @@ The extension also works for selecting multiple blocks. When you highlight and r
 
 Note that the extension does a simple search and replace. That means if aliases are nested in other words or already have links, it will still replace the instance with a new link.
 
-By default, the extensions replace synonyms using the `[synonym](((page-uid)))` format. To use tags instead, add a block that says "Use Tags" in the `[[roam/js/page-synonyms]]` page.
+PS! By default, the extensions replace synonyms using the `[synonym](((page-uid)))` format. To use tags instead, add a block that says "Use Tags" in the `[[roam/js/page-synonyms]]` page. Roam may crash for some using the `[synonym](((page-uid)))` format but will work through tags.


### PR DESCRIPTION
- People might not be aware that this fixes the bug if Roam keeps crashing when using the default formatting.