### PR TITLE
Origin/gcal improve meeting links

### DIFF
--- a/components/ExtensionPageLayout.tsx
+++ b/components/ExtensionPageLayout.tsx
@@ -90,6 +90,7 @@ export const contributors = {
   "Amanda Peyton": "http://amandapeyton.com/",
   "Daniel Rahal": "https://twitter.com/danhrahal",
   "Orkhan Allahverdi": "https://twitter.com/o_allahverdi",
+  "Monty Kosma": "https://twitter.com/mkosma",
 };
 
 export const emojisToTooltip = {

--- a/pages/docs/extensions/google-calendar.mdx
+++ b/pages/docs/extensions/google-calendar.mdx
@@ -31,8 +31,8 @@ On the `import` tab, you will find numerous fields used to configure the calenda
 - `{end}` - the end time of the event. Add a colon and format to customize the end time format. For example, `{end:hh:mmaaaaa}` will resolve to `12:00p`
 - `{attendees}` - the attendees of the event, using either their display name if available or email if not, each of whom are tagged and comma delimited.
 
-By default, `Format` will be `{summary} ({start:hh:mm a} - {end:hh:mm a}) - {confLink}`
-Sample custom format: `{{[[TODO]]}} {start:hh:mmaaaaa} - {end:hh:mmaaaaa} - {summary} - {confLink}`
+By default, `Format` will be `{summary} ({start:hh:mm a} - {end:hh:mm a}) - [Meet|Zoom]{link}`
+Sample custom format: `{{[[TODO]]}} {start:hh:mmaaaaa} - {end:hh:mmaaaaa} - {summary}{confLink}`
 
 See the [date-fns library](https://date-fns.org/v2.22.1/docs/format) for more details on time formats.
 

--- a/pages/docs/extensions/google-calendar.mdx
+++ b/pages/docs/extensions/google-calendar.mdx
@@ -1,7 +1,7 @@
 ---
 layout: 'ExtensionPageLayout'
 description: 'The Google Calendar to Roam Integration allows users to import the list of events on a given day into their daily notes page.'
-contributors: Eric Anderson 💵, Joe Ocampo 💵, George Corple 💵, Marco Brambilla 💵💻, David Schulman, 💵 Monty Kosma 💵
+contributors: Eric Anderson 💵, Joe Ocampo 💵, George Corple 💵, Marco Brambilla 💵, David Schulman 💵, Monty Kosma 💻
 loom: 47aded52527343929e6be51cbee85052
 ---
 

--- a/pages/docs/extensions/google-calendar.mdx
+++ b/pages/docs/extensions/google-calendar.mdx
@@ -1,7 +1,7 @@
 ---
 layout: 'ExtensionPageLayout'
 description: 'The Google Calendar to Roam Integration allows users to import the list of events on a given day into their daily notes page.'
-contributors: Eric Anderson 💵, Joe Ocampo 💵, George Corple 💵, Marco Brambilla 💵💻, David Schulman 💵
+contributors: Eric Anderson 💵, Joe Ocampo 💵, George Corple 💵, Marco Brambilla 💵💻, David Schulman, 💵 Monty Kosma 💵
 loom: 47aded52527343929e6be51cbee85052
 ---
 
@@ -17,7 +17,7 @@ On the `import` tab, you will find numerous fields used to configure the calenda
 
 `Calendars` specify which calendars you would like Roam to read before importing. If you specify more than one, it will read from all of those calendars. You must use the calendar ID provided by Google which you could find in the calendar settings. This will usually be your gmail address, such as `dvargas92495@gmail.com`.
 
-`Include Event Link` hyperlinks the event summary with a link to the google calendar event. This field is ignored if you specify a `Format`.
+`Include Event Link` hyperlinks the event summary with a link to the google calendar event. This field also now applies if you specify a `Format`.
 
 `Skip Free` filters out the events from your calendar that you've set to 'Free'
 
@@ -25,11 +25,15 @@ On the `import` tab, you will find numerous fields used to configure the calenda
 - `{summary}` - the name of the event 
 - `{link}` - the link for the event
 - `{hangout}` - the hangout link for the event
+- `{confLink}` - a conference link for the event (labeled 'Meet' or 'Zoom' as appropriate)
 - `{location}` - the location for the event
 - `{start}` - the start time of the event. Add a colon and format to customize the start time format. For example, `{start:hh:mm}` will resolve to `12:00`
-- `{end}` - the end time of the event. Add a colon and format to customize the end time format. For example, `{end:hh:mm}` will resolve to `12:00`
+- `{end}` - the end time of the event. Add a colon and format to customize the end time format. For example, `{end:hh:mmaaaaa}` will resolve to `12:00p`
 - `{attendees}` - the attendees of the event, using either their display name if available or email if not, each of whom are tagged and comma delimited.
-By default, `Format` will be `{summary} ({start:hh:mm am} - {end:hh:mm a}) - [Meet]({hangout})`
+
+By default, `Format` will be `{summary} ({start:hh:mm a} - {end:hh:mm a}) - {confLink}`
+
+See the [date-fns library](https://date-fns.org/v2.22.1/docs/format) for more details on time formats.
 
 In any page, activate the Roam Command Palette by hitting CTRL+P on windows or CMD+P on Mac, then click the `Import Google Calendar` command. The extension will fill the page with the events you have for that day. It will be displayed in the timezone of your browser. It will use either the page's title if it's a daily note, or the current date if it's not.
 

--- a/pages/docs/extensions/google-calendar.mdx
+++ b/pages/docs/extensions/google-calendar.mdx
@@ -32,6 +32,7 @@ On the `import` tab, you will find numerous fields used to configure the calenda
 - `{attendees}` - the attendees of the event, using either their display name if available or email if not, each of whom are tagged and comma delimited.
 
 By default, `Format` will be `{summary} ({start:hh:mm a} - {end:hh:mm a}) - {confLink}`
+Sample custom format: `{{[[TODO]]}} {start:hh:mmaaaaa} - {end:hh:mmaaaaa} - {summary} - {confLink}`
 
 See the [date-fns library](https://date-fns.org/v2.22.1/docs/format) for more details on time formats.
 

--- a/src/entries/google-calendar.ts
+++ b/src/entries/google-calendar.ts
@@ -161,6 +161,14 @@ const fetchGoogleCalendar = async (): Promise<string[]> => {
       return events
         .filter((e: Event) => !skipFree || e.transparency !== "transparent")
         .map((e: Event) => { 
+          const summaryText = resolveSummary(e);
+          const summary = includeLink && e.htmlLink 
+                ? `[${summaryText}](${e.htmlLink})` 
+                : summaryText;
+          const meetLink = e.hangoutLink ? ` - [Meet](${e.hangoutLink})` : "";
+          const zoomLink = e.location && e.location.indexOf("zoom.us") > -1 
+                ? ` - [Zoom](${e.location})`
+                : "";
           if (format) {
             return (format as string)
               .replace("/Summary", resolveSummary(e))
@@ -169,9 +177,10 @@ const fetchGoogleCalendar = async (): Promise<string[]> => {
               .replace("/Location", e.location || "")
               .replace("/Start Time", resolveDate(e.start))
               .replace("/End Time", resolveDate(e.end))
-              .replace("{summary}", resolveSummary(e))
+              .replace("{summary}", summary)
               .replace("{link}", e.htmlLink || "")
               .replace("{hangout}", e.hangoutLink || "")
+              .replace("{confLink}", meetLink || zoomLink || "")
               .replace("{location}", e.location || "")
               .replace("{attendees}", resolveAttendees(e) || "")
               .replace(/{start:?(.*?)}/, (_, format) =>
@@ -181,19 +190,7 @@ const fetchGoogleCalendar = async (): Promise<string[]> => {
                 resolveDate({ ...e.end, format })
               );
           } else {
-            const summaryText = resolveSummary(e);
-            const summary =
-              includeLink && e.htmlLink
-                ? `[${summaryText}](${e.htmlLink})`
-                : summaryText;
-            const meetLink = e.hangoutLink ? ` - [Meet](${e.hangoutLink})` : "";
-            const zoomLink =
-              e.location && e.location.indexOf("zoom.us") > -1
-                ? ` - [Zoom](${e.location})`
-                : "";
-            return `${summary} (${resolveDate(e.start)} - ${resolveDate(
-              e.end
-            )})${meetLink}${zoomLink}`;
+            return `${summary} (${resolveDate(e.start)} - ${resolveDate(e.end)})${meetLink}${zoomLink}`;
           }
         });
     })

--- a/src/entries/google-calendar.ts
+++ b/src/entries/google-calendar.ts
@@ -180,7 +180,7 @@ const fetchGoogleCalendar = async (): Promise<string[]> => {
               .replace("{summary}", summary)
               .replace("{link}", e.htmlLink || "")
               .replace("{hangout}", e.hangoutLink || "")
-              .replace("{confLink}", meetLink || zoomLink || "")
+              .replace("{confLink}", (meetLink + zoomLink) || "")
               .replace("{location}", e.location || "")
               .replace("{attendees}", resolveAttendees(e) || "")
               .replace(/{start:?(.*?)}/, (_, format) =>


### PR DESCRIPTION
Addresses #658 ...

In addition, the code {confLink} can be used in custom formats to specify [Meet] or [Zoom] appropriately depending on which one is in a calendar entry.

I've also arranged things so that the includeLink flag applies to custom formats.
